### PR TITLE
Upgrade to func_adl 0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 flask
 Flask-WTF
 flask-restful
-func-adl-uproot==0.7
+func-adl-uproot==0.8
 func-adl==1.0.0a18


### PR DESCRIPTION
Pick up new version of the library to fix a bug in qastle 

Supports selects like this
```
query = "EventDataset().Where(lambda event: event.MVA3lCERN_weight_ttH > 0.3 and event.MVA3lCERN_weight_ttW < 0.75 and event.MVA3lCERN_weight_ttZ < 0.75 and event.MVA3lCERN_weight_VV < 0.75 and event.MVA3lCERN_weight_ttbar < 0.3).Select('lambda event: (event.MVA3lCERN_weight_ttH)')"
```