### PR TITLE
Generate docker image with git tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,11 @@ name: CI/CD
 
 on:
   push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+
   pull_request:
 
 jobs:
@@ -39,11 +44,15 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
+    - name: Extract tag name
+      shell: bash
+      run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+      id: extract_tag_name
+
     - name: Build Uproot Image
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: sslhep/servicex_code_gen_func_adl_uproot
+        name: sslhep/servicex_code_gen_func_adl_uproot:${{ steps.extract_tag_name.outputs.imagetag }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tag: "${GITHUB_REF##*/}"
 


### PR DESCRIPTION
# Problem
The existing GitHub action does a fine job of testing the code and then building a docker image. This works for push operations. Ideally this should work when we tag a release so that we get a docker image for the tagged version.

# Approach
This was not working. The GitHub action for docker pushes wasn't respecting tags on master branch. Changed the action step to create a complete docker image name with the tag as part of that name. That seems to fix it.