### PR TITLE
Upgrade to Func_ADL_Uproot 0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 flask
 Flask-WTF
 flask-restful
-func-adl-uproot==0.8
+func-adl-uproot==0.11
 func-adl==1.0.0a18

--- a/servicex/code_generator_service/ast_translator.py
+++ b/servicex/code_generator_service/ast_translator.py
@@ -103,7 +103,7 @@ class AstTranslator:
 
             # Zip up everything in the directory - we are going to ship it as back as part
             # of the message.
-            z_filename = os.path.join(str(tempdir), f'joined.zip')
+            z_filename = os.path.join(str(tempdir), 'joined.zip')
             zip_h = zipfile.ZipFile(z_filename, 'w', zipfile.ZIP_DEFLATED)
             self.zipdir(r.output_dir, zip_h)
             zip_h.close()


### PR DESCRIPTION
There is a new version of qastle (0.7) which handles all the previously missing python operators (%, **, //, &, |, ^, <<, >>) and a new version of func_adl_uproot (0.11) which now handles all these and the if/else ternary expressions correctly

[Solution to ServiceX issue 123](https://github.com/ssl-hep/ServiceX/issues/123)

This PR also contains a commit that finally fixes the generation of new docker images on git tags