### PR TITLE
Generate docker image with git tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,11 @@ name: CI/CD
 
 on:
   push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+
   pull_request:
 
 jobs:
@@ -39,11 +44,15 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
+    - name: Extract tag name
+      shell: bash
+      run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+      id: extract_tag_name
+
     - name: Build Uproot Image
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: sslhep/servicex_code_gen_func_adl_uproot
+        name: sslhep/servicex_code_gen_func_adl_uproot:${{ steps.extract_tag_name.outputs.imagetag }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tag: "${GITHUB_REF##*/}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 flask
 Flask-WTF
 flask-restful
-func-adl-uproot==0.8
+func-adl-uproot==0.11
 func-adl==1.0.0a18

--- a/servicex/code_generator_service/ast_translator.py
+++ b/servicex/code_generator_service/ast_translator.py
@@ -103,7 +103,7 @@ class AstTranslator:
 
             # Zip up everything in the directory - we are going to ship it as back as part
             # of the message.
-            z_filename = os.path.join(str(tempdir), f'joined.zip')
+            z_filename = os.path.join(str(tempdir), 'joined.zip')
             zip_h = zipfile.ZipFile(z_filename, 'w', zipfile.ZIP_DEFLATED)
             self.zipdir(r.output_dir, zip_h)
             zip_h.close()


### PR DESCRIPTION
# Problem
We generate docker images as part of the CI for branch pushes, but this doesn't happen for tags.

Partial solution to [ServiceX Issue 110](https://github.com/ssl-hep/ServiceX/issues/110)
