### PR TITLE
Freeze dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir ./servicex
 
 COPY requirements.txt requirements.txt
 
+RUN pip install safety==1.9.0
+RUN safety check -r requirements.txt
 RUN pip install -r requirements.txt
 RUN pip install gunicorn
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements needed to run the app.
-flask
-Flask-WTF
-flask-restful
-func-adl-uproot==0.11
+Flask==1.1.2
+Flask-RESTful==0.3.8
+Flask-WTF==0.14.3
 func-adl==1.0.0a18
+func-adl-uproot==0.11


### PR DESCRIPTION
Partially fulfills #92 . All libraries in requirements.txt are fixed to the minor version number and safety is run to check for vulnerabilities
