### PR TITLE
Update func_adl_uproot requirement to 0.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Flask==1.1.2
 Flask-RESTful==0.3.8
 Flask-WTF==0.14.3
 func-adl==1.0.0a18
-func-adl-uproot==0.11
+func-adl-uproot==0.13


### PR DESCRIPTION
Summary of updates between func_adl_uproot versions 0.11 and 0.13:

- Extended Python version compatibility both backwards (2.7, 3.6) and forwards (3.9)
- Fixed major bug in indexing of columns in tuples and lists (did not affect accessing columns by name)
- The awkward0 and uproot3 package names have been updated to ensure safety through the awkward1/uproot4 migration (support for these will come later)