### PR TITLE
Set `qastle` version in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-RESTful==0.3.8
 Flask-WTF==0.14.3
 func-adl==1.0.0a18
 func-adl-uproot==1.4
+qastle==0.11.0


### PR DESCRIPTION
The latest version of `qastle` fixes a bug when running `copy.deepcopy()` on LINQ nodes. This version should get pulled in automatically the next time the Docker image is built, but the `qastle` version might as well be set just like with `func_adl` and `func_adl_uproot`.