### PR TITLE
Pin itsdangerous to avoid flask error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ func-adl==2.3
 func-adl.ast==2.3
 func-adl-uproot==1.8.0
 qastle==0.15.0
+# Incompatibility between flask and the latest itsdangerous
+itsdangerous==2.0.1


### PR DESCRIPTION
# Problem
There is an [incompatibility in the latest version of itsdagerous library](https://serverfault.com/questions/1094062/error-from-itsdangerous-import-json-as-json-importerror-cannot-import-name-j)

## Approach
Pin to the last working version