### PR TITLE
Incompatible dependencies with flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ func-adl-uproot==1.8.0
 qastle==0.15.0
 # Incompatibility between flask and the latest itsdangerous
 itsdangerous==2.0.1
+# Avoid import error in Flask
+MarkupSafe == 2.0.1
+jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ qastle==0.15.0
 # Incompatibility between flask and the latest itsdangerous
 itsdangerous==2.0.1
 # Avoid import error in Flask
-MarkupSafe == 2.0.1
+werkzeug==2.0.3
 jinja2==3.0.3


### PR DESCRIPTION
We are getting build errors with our pinned version of flask. Jinja2 and Werkzeug need to be pinned